### PR TITLE
[FIX][F-35] Fix /books query params

### DIFF
--- a/frontend/src/app/book-list/book-list.component.ts
+++ b/frontend/src/app/book-list/book-list.component.ts
@@ -18,7 +18,7 @@ export class BookListComponent implements ListComponent, OnInit {
   links: HypermediaCollection;
   books: Array<Book>;
   selectedSortTypeName: string = "Domyślnie";
-  selectedPageSize: number = 20;
+  selectedPageSize: number;
   pageSizes = [10, 20, 50, 100];
   languages = new Array<Pair>;
   selectedLanguages = new Array<string>;
@@ -39,7 +39,11 @@ export class BookListComponent implements ListComponent, OnInit {
   ) { }
 
   ngOnInit(): void {
-    this.getAllByParams();
+    this.route.queryParams.subscribe(params => {
+      const validParams = this.validateParams(params);
+      this.initializeValuesFromParams(validParams);
+      this.getAllByParams(validParams);
+    });
     this.getAllLanguages();
   }
 
@@ -98,5 +102,38 @@ export class BookListComponent implements ListComponent, OnInit {
     queryParams[paramName] = value;
     this.router.navigate([this.routeName], { queryParams: queryParams });
     return queryParams;
+  }
+
+  private initializeValuesFromParams(params: Params) {
+    if ('size' in params) {
+      this.selectedPageSize = +params['size'];
+    }
+    if ('lang' in params) {
+      this.selectedLanguages = params['lang'];
+    }
+    if ('sort' in params) {
+      const sortType = this.sortTypes.find(st => st.queryParam === params['sort']);
+      if (sortType) {
+        this.selectedSortTypeName = sortType.name;
+      }
+    }
+  }
+
+  private validateParams(params: Params): Params {
+    const validatedParams = { ...params };
+
+    if (!validatedParams['size'] || validatedParams['size'] < 0) {
+      validatedParams['size'] = 20;
+    }
+
+    if (!validatedParams['page'] || validatedParams['page'] < 0) {
+      validatedParams['page'] = 0;
+    }
+
+    const sortType = this.sortTypes.find(st => st.queryParam === validatedParams['sort']);
+    if (!validatedParams['sort'] || !sortType) {
+      validatedParams['sort'] = "";
+    }
+    return validatedParams;
   }
 }


### PR DESCRIPTION
## What?
URL query params (make them work) and add page GUI selecting buttons styling.

## Why?
The book list didn't reload when url query params were changed. There were always basic book list of 20 elements.

## How?
I've created private methods to: 
 - validate params to send correct values to server
 - set 'selected' class to GUI elements depend on query params' values

## Testing?
Add query params to browser URL address. For now implemented are the following: size, page, lang, sort.
When params have valid value the GUI select buttons should be highlighted depend on params' values.

## Screenshots
0

## Anything Else?
There will be more params in the next steps (more filter options).