### PR TITLE
[FEATURE][F-40] Implement token refreshing in frontend

### DIFF
--- a/backend/src/main/java/com/example/libraryapp/domain/config/CustomLogoutHandler.java
+++ b/backend/src/main/java/com/example/libraryapp/domain/config/CustomLogoutHandler.java
@@ -2,9 +2,11 @@ package com.example.libraryapp.domain.config;
 
 import com.example.libraryapp.domain.token.AccessToken;
 import com.example.libraryapp.domain.token.AccessTokenRepository;
+import com.example.libraryapp.domain.token.TokenType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
@@ -21,9 +23,9 @@ public class CustomLogoutHandler implements LogoutHandler {
             HttpServletResponse response,
             Authentication authentication
     ) {
-        String authHeader = request.getHeader("Authorization");
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+        if (authHeader == null || !authHeader.startsWith(TokenType.BEARER.getPrefix())) {
             return;
         }
 

--- a/backend/src/main/java/com/example/libraryapp/domain/config/CustomSecurityConfig.java
+++ b/backend/src/main/java/com/example/libraryapp/domain/config/CustomSecurityConfig.java
@@ -44,6 +44,7 @@ public class CustomSecurityConfig {
                                 (request, response, authentication) -> SecurityContextHolder.clearContext()
                         ))
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .headers(headers -> headers
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
         ;
@@ -55,6 +56,7 @@ public class CustomSecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList("http://localhost:4200"));
         configuration.setAllowedMethods(Arrays.asList("GET","POST", "PUT", "OPTIONS"));
+        configuration.setAllowCredentials(true);
         configuration.setAllowedHeaders(List.of("*"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/backend/src/main/java/com/example/libraryapp/domain/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/libraryapp/domain/config/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.example.libraryapp.domain.config;
 
 import com.example.libraryapp.domain.token.TokenService;
+import com.example.libraryapp.domain.token.TokenType;
 import com.example.libraryapp.management.Message;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -37,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         String requestURI = request.getRequestURI();
         String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if ((authHeader == null || !authHeader.startsWith("Bearer ")) &&  !requestURI.endsWith("/refresh-token")) {
+        if ((authHeader == null || !authHeader.startsWith(TokenType.BEARER.getPrefix())) &&  !requestURI.endsWith("/refresh-token")) {
             filterChain.doFilter(request,response);
             return;
         }

--- a/backend/src/main/java/com/example/libraryapp/domain/config/SecurityUtils.java
+++ b/backend/src/main/java/com/example/libraryapp/domain/config/SecurityUtils.java
@@ -10,8 +10,10 @@ import java.security.SecureRandom;
 
 public class SecurityUtils {
     public static final String FINGERPRINT_NAME = "userFingerprint";
-    private static final String FINGERPRINT_COOKIE_NAME = "Set-Cookie";
-    private static final String FINGERPRINT_COOKIE_PATTERN = "__Secure-Fgp=%s; SameSite=Strict; HttpOnly; Secure";
+    public static final String FINGERPRINT_COOKIE_NAME = "myCookie";
+    //    public static final String FINGERPRINT_COOKIE_NAME = "__Secure-Fgp";
+    public static final String FINGERPRINT_COOKIE_HEADER = "Set-Cookie";
+    private static final String FINGERPRINT_COOKIE_PATTERN = FINGERPRINT_COOKIE_NAME + "=%s; SameSite=Strict; HttpOnly"; // add Secure if the SSL certificate is available
     private static final int FINGERPRINT_LENGTH = 50;
 
     public static String generateFingerprintValue() {
@@ -19,7 +21,7 @@ public class SecurityUtils {
     }
 
     public static Cookie generateFingerprintCookie(String text) {
-        return new Cookie(FINGERPRINT_COOKIE_NAME, FINGERPRINT_COOKIE_PATTERN.formatted(text));
+        return new Cookie(FINGERPRINT_COOKIE_HEADER, FINGERPRINT_COOKIE_PATTERN.formatted(text));
     }
 
     public static String generateStringOfLength(int length) {

--- a/backend/src/main/java/com/example/libraryapp/domain/token/TokenService.java
+++ b/backend/src/main/java/com/example/libraryapp/domain/token/TokenService.java
@@ -71,7 +71,7 @@ public class TokenService {
     }
 
     public Optional<String> findToken(HttpServletRequest request) {
-        String BEARER_PREFIX = "Bearer ";
+        String BEARER_PREFIX = TokenType.BEARER.getPrefix();
         Optional<String> token = Optional.of(request.getHeader(HttpHeaders.AUTHORIZATION))
                 .filter(authHeader -> authHeader.startsWith(BEARER_PREFIX))
                 .map(authHeader -> authHeader.substring(BEARER_PREFIX.length()));
@@ -81,7 +81,7 @@ public class TokenService {
 
     public Optional<String> findFingerprint(HttpServletRequest request) {
         Optional<String> fingerprint = Arrays.stream(request.getCookies())
-                .filter(cookie -> "__Secure-Fgp".equals(cookie.getName()))
+                .filter(cookie -> SecurityUtils.FINGERPRINT_COOKIE_NAME.equals(cookie.getName()))
                 .findFirst()
                 .map(Cookie::getValue);
         if (fingerprint.isEmpty()) throw new JwtException(Message.ACCESS_DENIED);

--- a/backend/src/main/java/com/example/libraryapp/domain/token/TokenType.java
+++ b/backend/src/main/java/com/example/libraryapp/domain/token/TokenType.java
@@ -1,5 +1,14 @@
 package com.example.libraryapp.domain.token;
 
+import lombok.Getter;
+
+@Getter
 public enum TokenType {
-    BEARER
+    BEARER("Bearer ");
+
+    private final String prefix;
+
+    TokenType(String prefix) {
+        this.prefix = prefix;
+    }
 }

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -11,7 +11,7 @@
         <li><a routerLink=""><i class="fa fa-lg fa-home"></i></a></li>
         <li *ngIf="!isLoggedIn"><a href="/login">Login</a></li>
         <li *ngIf="!isLoggedIn"><a href="#">Register</a></li>
-        <li *ngIf="isLoggedIn"><a [routerLink]="['']" routerLinkActive="active" (click)="logout()">Logout</a></li>
+        <li *ngIf="isLoggedIn"><a [routerLink]="['']" (click)="logout()">Logout</a></li>
       </ul>
     </div>
   </div>

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -6,13 +6,21 @@
         <li><i class="fa fa-envelope-o"></i> info&#64;domain.com</li>
       </ul>
     </div>
+
     <div class="fl_right">
-      <ul>
-        <li><a routerLink=""><i class="fa fa-lg fa-home"></i></a></li>
-        <li *ngIf="!isLoggedIn"><a href="/login">Login</a></li>
-        <li *ngIf="!isLoggedIn"><a href="#">Register</a></li>
-        <li *ngIf="isLoggedIn"><a [routerLink]="['']" (click)="logout()">Logout</a></li>
-      </ul>
+      <ng-container>
+        <ul *ngIf="!isLoggedIn; else loggedIn">
+          <li><a routerLink=""><i class="fa fa-lg fa-home"></i></a></li>
+          <li><a href="/login">Login</a></li>
+          <li><a href="#">Register</a></li>
+        </ul>
+      </ng-container>
+      <ng-template #loggedIn>
+        <ul>
+          <li><a routerLink=""><i class="fa fa-lg fa-home"></i></a></li>
+          <li><a [routerLink]="['']" (click)="logout()">Logout</a></li>
+        </ul>
+      </ng-template>
     </div>
   </div>
 </div>

--- a/frontend/src/app/login/login.component.ts
+++ b/frontend/src/app/login/login.component.ts
@@ -31,7 +31,7 @@ export class LoginComponent {
           this.router.navigate(['/userprofile']);
         },
         error: err => {
-          console.error(err.error.message);
+          console.log("Błędne hasło lub email");
         }
       });
     }

--- a/frontend/src/app/services/authentication.service.ts
+++ b/frontend/src/app/services/authentication.service.ts
@@ -1,50 +1,122 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Login } from '../login/login.component';
-import { BehaviorSubject, tap } from 'rxjs';
+import { BehaviorSubject, Observable, catchError, tap, throwError } from 'rxjs';
+import { ConfigService } from './config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthenticationService {
-  private baseURL = "http://localhost:8080/api/v1/authenticate";
-  private readonly TOKEN_NAME = "libraryToken";
-  private _isLoggedIn$ = new BehaviorSubject<boolean>(false);
+  private baseURL;
+  private readonly ACCESS_TOKEN_NAME = "access_token";
+  private readonly REFRESH_TOKEN_NAME = "refresh_token";
+  private _isLoggedInSubject = new BehaviorSubject<boolean>(false);
+  isLoggedIn$ = this._isLoggedInSubject.asObservable();
 
-  get token() {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem(this.TOKEN_NAME);
+  private accessTokenSubject: BehaviorSubject<string | null>;
+  private refreshTokenSubject: BehaviorSubject<string | null>;
+  private refreshTokenTimeout: any;
+
+  public get accessToken(): string | null {
+    return this.accessTokenSubject.value;
+  }
+
+  public get refreshToken(): string | null {
+    return this.refreshTokenSubject.value;
+  }
+
+  constructor(
+    private http: HttpClient,
+    private configService: ConfigService
+  ) {
+    this.baseURL = configService.getApiUrl();
+    this.accessTokenSubject = new BehaviorSubject<string | null>(this.getFromStorage(this.ACCESS_TOKEN_NAME));
+    this.refreshTokenSubject = new BehaviorSubject<string | null>(this.getFromStorage(this.REFRESH_TOKEN_NAME));
+
+    let tokensAreValid = this.isValidToken(this.refreshToken) && this.isValidToken(this.accessToken);
+    this._isLoggedInSubject.next(tokensAreValid);
+  }
+
+  authenticate(login: Login): Observable<any> {
+    return this.http.post<Token>(`${this.baseURL}/authenticate`, login, { withCredentials: true }).pipe(
+      tap(response => {
+        sessionStorage.setItem(this.ACCESS_TOKEN_NAME, response.access_token);
+        sessionStorage.setItem(this.REFRESH_TOKEN_NAME, response.refresh_token);
+        this._isLoggedInSubject.next(true);
+        this.accessTokenSubject.next(response.access_token);
+        this.refreshTokenSubject.next(response.refresh_token);
+        this.startRefreshTokenTimer();
+      })
+    );
+  }
+
+  refreshTokenRequest(): Observable<any> {
+    if (!this.refreshToken) {
+      return throwError(() => 'No refresh token available');
     }
-    return null;
-  }
 
-  get isLoggedIn$() {
-    return this._isLoggedIn$.asObservable();
-  }
-
-  constructor(private http: HttpClient) { 
-    this._isLoggedIn$.next(!!this.token);
-  }
-
-  authenticate(login: Login) {
-    return this.http.post<Token>(this.baseURL, login).pipe(
-      tap(token => {
-        localStorage.setItem(this.TOKEN_NAME, token.token);
-        this._isLoggedIn$.next(true);
+    return this.http.post<Token>(`${this.baseURL}/refresh-token`, {}, { withCredentials: true }).pipe(
+      tap(response => {
+        sessionStorage.setItem(this.ACCESS_TOKEN_NAME, response.access_token);
+        sessionStorage.setItem(this.REFRESH_TOKEN_NAME, response.refresh_token);
+        this._isLoggedInSubject.next(true);
+        this.accessTokenSubject.next(response.access_token);
+        this.refreshTokenSubject.next(response.refresh_token);
+        this.startRefreshTokenTimer();
+      }),
+      catchError(error => {
+        this.logout();
+        return throwError(() => error);
       })
     );
   }
 
   logout() {
-    this.http.post(`${this.baseURL}/logout`, undefined).subscribe({
-      next: () => {
-        localStorage.removeItem(this.TOKEN_NAME);
-        this._isLoggedIn$.next(false);
-      }
-    });
+      this.http.post(`${this.baseURL}/authenticate/logout`, {}).subscribe({
+        next: () => {
+          sessionStorage.removeItem(this.ACCESS_TOKEN_NAME);
+          sessionStorage.removeItem(this.REFRESH_TOKEN_NAME);
+          this._isLoggedInSubject.next(false);
+          this.accessTokenSubject.next(null);
+          this.refreshTokenSubject.next(null);
+          this.stopRefreshTokenTimer();
+        }
+      });
+    }
+
+  private startRefreshTokenTimer() {
+    const token = this.accessToken;
+    if (token) {
+      const jwtToken = JSON.parse(atob(token.split('.')[1]));
+      const expires = new Date(jwtToken.exp * 1000);
+      const timeout = expires.getTime() - Date.now() - 60000; // 1 minute before expiry
+      this.refreshTokenTimeout = setTimeout(() => this.refreshTokenRequest().subscribe(), timeout);
+    }
+  }
+
+  private isValidToken(token: string | null): boolean {
+    if (token) {
+      const jwtToken = JSON.parse(atob(token.split('.')[1]));
+      const expires = new Date(jwtToken.exp * 1000);
+      return expires.getTime() > Date.now();
+    }
+    return false;
+  }
+
+  private stopRefreshTokenTimer() {
+    clearTimeout(this.refreshTokenTimeout);
+  }
+
+  private getFromStorage(tokenName: string) {
+    if (typeof window !== 'undefined') {
+      return sessionStorage.getItem(tokenName);
+    }
+    return null;
   }
 }
 
 class Token {
-  token: string;
+  access_token: string;
+  refresh_token: string;
 }

--- a/frontend/src/app/services/book-items.service.ts
+++ b/frontend/src/app/services/book-items.service.ts
@@ -2,15 +2,22 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { BookItemsPage } from '../models/book-items-page';
+import { ConfigService } from './config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class BookItemsService {
 
-  private baseURL = "http://localhost:8080/api/v1/book-items"
+  private baseURL;
 
-  constructor(private http: HttpClient) { }
+  constructor(
+    private http: HttpClient,
+    configService: ConfigService
+  ) { 
+    let baseURL = configService.getApiUrl();
+    this.baseURL = `${baseURL}/book-items`
+  }
 
   getAllBookItems(page: number, size: number, sort: string): Observable<BookItemsPage> {
     const params = new HttpParams().set("page", page).set("size", size).set("sort", sort);

--- a/frontend/src/app/services/books.service.ts
+++ b/frontend/src/app/services/books.service.ts
@@ -6,15 +6,21 @@ import { Book } from '../models/book';
 import { Pair } from '../shared/pair';
 import { Params } from '@angular/router';
 import { BookItem } from '../models/book-item';
+import { ConfigService } from './config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class BooksService {
+  private baseURL;
 
-  private baseURL = "http://localhost:8080/api/v1/books"
-
-  constructor(private http: HttpClient) { }
+  constructor(
+    private http: HttpClient,
+    configService: ConfigService
+  ) { 
+    let baseURL = configService.getApiUrl();
+    this.baseURL = `${baseURL}/books`
+  }
 
   getAllBooks(queryParams?: Params): Observable<BooksPage> {
     return this.http.get<BooksPage>(this.baseURL, { params: queryParams });

--- a/frontend/src/app/services/books.service.ts
+++ b/frontend/src/app/services/books.service.ts
@@ -23,18 +23,18 @@ export class BooksService {
   }
 
   getAllBooks(queryParams?: Params): Observable<BooksPage> {
-    return this.http.get<BooksPage>(this.baseURL, { params: queryParams });
+    return this.http.get<BooksPage>(this.baseURL, { params: queryParams, withCredentials: true });
   }
 
   getBookById(id: number): Observable<Book> {
-    return this.http.get<Book>(`${this.baseURL}/${id}`);
+    return this.http.get<Book>(`${this.baseURL}/${id}`, { withCredentials: true });
   }
 
   getBookItemsByBookId(id: number): Observable<BookItem[]> {
-    return this.http.get<BookItem[]>(`${this.baseURL}/${id}/book-items`)
+    return this.http.get<BookItem[]>(`${this.baseURL}/${id}/book-items`, { withCredentials: true })
   }
 
   getLanguageListCount(): Observable<Pair[]>{
-    return this.http.get<Pair[]>(`${this.baseURL}/languages/count`)
+    return this.http.get<Pair[]>(`${this.baseURL}/languages/count`, { withCredentials: true })
   }
 }

--- a/frontend/src/app/services/config.service.spec.ts
+++ b/frontend/src/app/services/config.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ConfigService } from './config.service';
+
+describe('ConfigService', () => {
+  let service: ConfigService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ConfigService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/services/config.service.ts
+++ b/frontend/src/app/services/config.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfigService {
+  private baseUrl: string = environment.apiUrl;
+
+  getApiUrl(): string {
+    return this.baseUrl;
+  }
+}
+
+export const AUTHORIZED_ENDPOINTS = [
+  "/refresh-token",
+];

--- a/frontend/src/app/services/custom.interceptor.ts
+++ b/frontend/src/app/services/custom.interceptor.ts
@@ -1,24 +1,78 @@
-import { HTTP_INTERCEPTORS, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HTTP_INTERCEPTORS, HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { BehaviorSubject, Observable, catchError, filter, switchMap, take, throwError } from 'rxjs';
 import { AuthenticationService } from './authentication.service';
 import { Injectable } from '@angular/core';
+import { AUTHORIZED_ENDPOINTS } from './config.service';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
+  private isRefreshing = false;
+  private refreshTokenSubject: BehaviorSubject<any> = new BehaviorSubject<any>(null);
 
   constructor(private authService: AuthenticationService){}
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    const token = this.authService.token;
-    if (token) {
-      const requestClone = req.clone({
+    const token = this.getToken(req);
+    const endpointIsAuthorized = AUTHORIZED_ENDPOINTS.some(endpoint => req.url.includes(endpoint));
+    if (endpointIsAuthorized && token) {
+      req = this.addTokenHeader(req, token);
+    }
+
+    return next.handle(req).pipe(
+      catchError(error => {
+        if (req.url.includes('/refresh-token')) {
+          return throwError(() => error);
+        }
+        if (error instanceof HttpErrorResponse && error.status === 401) {
+          return this.handle401Error(req, next);
+        }
+        return throwError(() => error);
+      })
+    );
+  }
+
+  private getToken(req: HttpRequest<any>) {
+    if (req.url.endsWith("/refresh-token")) {
+      return this.authService.refreshToken;
+    } else {
+      return this.authService.accessToken;
+    }
+  }
+
+  private addTokenHeader(request: HttpRequest<any>, token: string) {
+    return request.clone({
       setHeaders: {
           Authorization: `Bearer ${token}`
         }
       });
-      return next.handle(requestClone);
+  }
+
+  private handle401Error(request: HttpRequest<any>, next: HttpHandler) {
+    if (!this.isRefreshing) {
+      this.isRefreshing = true;
+      this.refreshTokenSubject.next(null);
+
+      return this.authService.refreshTokenRequest().pipe(
+        switchMap((response: any) => {
+          this.isRefreshing = false;
+          this.refreshTokenSubject.next(response.refresh_token);
+          return next.handle(this.addTokenHeader(request, response.access_token));
+        }),
+        catchError((err) => {
+          this.isRefreshing = false;
+          this.authService.logout();
+          return throwError(() => err);
+        })
+      );
+    } 
+    
+    else {
+      return this.refreshTokenSubject.pipe(
+        filter(token => token != null),
+        take(1),
+        switchMap(jwt => next.handle(this.addTokenHeader(request, jwt)))
+      );
     }
-    return next.handle(req);
   }
 }
 

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+    production: true,
+    apiUrl: "http://localhost:8080/api/v1"
+}

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+    production: false,
+    apiUrl: "http://localhost:8080/api/v1"
+}


### PR DESCRIPTION
## What?
 - Added cors configuration in spring security config. It must have been accidentally deleted before.
 - Made the fingerprint cookie not secure. For now, it is not necessary for the cookie to be secure. This was done due to the lack of an SSL certificate, which is required for a secure cookie. This will be added back in the future.
 - Refactoring. Configuration files for the production and development environments have been created, containing the server's origin address, so that all services can use them.
 - The book service has been updated to add cookies to requests.
 - The authentication service has been updated to send silent requests when the access token expires.
 - Added the HTTP interceptor

## Why?
The http interceptor adds the Authorization header with a token to authorized requests. It adds the refresh token when the /refresh-token endpoint is executed; in other cases it adds the access token. It also intercepts 401 error - if the access token is expired, the interceptor attempts to refresh it and resend the request. User will be logged out if the refresh token is expired.

## How?
When the client receives tokens from the server, a timer is started, which, based on the expiration time of the access token, performs a silent refresh one minute before the access token expires. 
When the refresh token expires, user has no permission (valid tokens) to fetch authorized data and they have to authoenticate again.

## Testing?
Go to /login and log in. The server will return tokens in the response body and a cookie. The access token is valid for 15 minutes. One minute before expiration, a silent request will be made to the server to refresh the token.