### PR TITLE
[FIX][F-44] Fix the pagination logic in the book page

### DIFF
--- a/frontend/src/app/book-list/book-list.component.ts
+++ b/frontend/src/app/book-list/book-list.component.ts
@@ -52,10 +52,15 @@ export class BookListComponent implements ListComponent, OnInit {
 
   getAllByParams(queryParams?: Params) {
     this.booksService.getAllBooks(queryParams).subscribe(p => {
-      this.page = p.page;
-      this.books = p._embedded.bookDtoList;
-      this.links = p._links;
-    });
+      if (p._embedded && p._embedded.bookDtoList !== null) {
+          this.page = p.page;
+          this.books = p._embedded.bookDtoList;
+          this.links = p._links;
+      } else {
+          const newParams = this.updateQueryParams("page", 0);
+          this.getAllByParams(newParams);
+      }
+    })
   }
 
   getAllLanguages() {


### PR DESCRIPTION
## What?
This pull request fixes the pagination logic in the `getAllByParams()` method to handle cases where data retrieval based on provided parameters results in a null `bookDtoList`.

## Why?
The current pagination logic fails when the `_embedded` object is missing (`bookDtoList` is null), leading to incomplete or empty data being displayed to the user. This issue occurs especially when the requested page does not exist for the given page size, such as changing the page size to a larger value after navigating to a higher page number.

## How?
- Enhanced the `getAllByParams()` method to check if the `_embedded` object and `bookDtoList` are present.
- If the `_embedded` object is missing or `bookDtoList` is null, the method retries the request with the page parameter set to 0.

## Related Issue
Closes #57