### PR TITLE
[FIX][F-51] Fix the routes and profile accordion

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -39,35 +39,21 @@ const routes: Routes = [
       {path: "notifications", component: NotificationsComponent},
       {path: "borrowed-items", component: BorrowedItemsComponent},
       {path: "on-site-items", component: OnSiteItemsComponent},
-      {
-        path: "requested-items", 
-        component: RequestedItemsComponent, 
-        children: [
-          {path: "unsent", component: RequestedItemsUnsentComponent},
-          {path: "pending", component: RequestedItemsPendingComponent},
-          {path: "completed", component: RequestedItemsCompletedComponent},
-        ]
-      },
+
+      {path: "requested-items/unsent", component: RequestedItemsUnsentComponent},
+      {path: "requested-items/pending", component: RequestedItemsPendingComponent},
+      {path: "requested-items/completed", component: RequestedItemsCompletedComponent},
+      
       {path: "reservations", component: ReservationsComponent},
       {path: "renewable-items", component: RenewableItemsComponent},
       {path: "history", component: UserHistoryComponent},
-      {
-        path: "fees",
-        component: FeesComponent,
-        children: [
-          {path: "not-accounted", component: FeesNotAccountedComponent},
-          {path: "accounted", component: FeesAccountedComponent},
-        ]
-      },
-      {
-        path: "edit",
-        component: EditComponent,
-        children: [
-          {path: "password", component: EditPasswordComponent},
-          {path: "email", component: EditEmailComponent},
-          {path: "phone", component: EditPhoneNumberComponent},
-        ]
-      }
+
+      {path: "fees/not-accounted", component: FeesNotAccountedComponent},
+      {path: "fees/accounted", component: FeesAccountedComponent},
+
+      {path: "edit/password", component: EditPasswordComponent},
+      {path: "edit/email", component: EditEmailComponent},
+      {path: "edit/phone", component: EditPhoneNumberComponent},
     ]
   }
 ];

--- a/frontend/src/app/home-page/styles/framework.css
+++ b/frontend/src/app/home-page/styles/framework.css
@@ -60,8 +60,8 @@ img{width:auto; max-width:100%; height:auto; margin:0; padding:0; border:none; l
 
 /* Fonts
 --------------------------------------------------------------------------------------------------------------- */
-body, input, textarea, select{font-family:Verdana, Geneva, sans-serif;}
-h1, h2, h3, h4, h5, h6, .heading{font-family:Georgia, "Times New Roman", Times, serif;}
+body, input, textarea, select{font-family:var(--font-family-2);}
+h1, h2, h3, h4, h5, h6, .heading{font-family:var(--font-family-1);}
 
 
 /* Forms

--- a/frontend/src/app/home-page/styles/layout.css
+++ b/frontend/src/app/home-page/styles/layout.css
@@ -15,6 +15,8 @@ File: Layout CSS
 :root {
 	--main-color: #1C7AA8;
 	--button-hover-color: #155A7D;
+	--font-family-1: Georgia, "Times New Roman", Times, serif;
+	--font-family-2: Verdana, Geneva, sans-serif;
 }
 
 /* Rows
@@ -68,7 +70,7 @@ File: Layout CSS
 .container{padding:80px 0;}
 
 /* Content */
-.container .content{padding-left: 10px; border-left: 1px solid;}
+.container .content{padding-left: 10px;}
 
 .sectiontitle{margin-bottom:80px;}
 .sectiontitle *{margin:0;}

--- a/frontend/src/app/profile-dashboard/edit/edit-email/edit-email.component.ts
+++ b/frontend/src/app/profile-dashboard/edit/edit-email/edit-email.component.ts
@@ -8,5 +8,5 @@ import { ProfileSetting } from '../../profile-dashboard.component';
 })
 export class EditEmailComponent implements ProfileSetting {
   name: string = "Change e-mail address"
-  routerLink: string = "email";
+  routerLink: string = "edit/email";
 }

--- a/frontend/src/app/profile-dashboard/edit/edit-password/edit-password.component.ts
+++ b/frontend/src/app/profile-dashboard/edit/edit-password/edit-password.component.ts
@@ -8,5 +8,5 @@ import { ProfileSetting } from '../../profile-dashboard.component';
 })
 export class EditPasswordComponent implements ProfileSetting {
   name: string = "Change password";
-  routerLink: string = "password";
+  routerLink: string = "edit/password";
 }

--- a/frontend/src/app/profile-dashboard/edit/edit-phone-number/edit-phone-number.component.ts
+++ b/frontend/src/app/profile-dashboard/edit/edit-phone-number/edit-phone-number.component.ts
@@ -8,5 +8,5 @@ import { ProfileSetting } from '../../profile-dashboard.component';
 })
 export class EditPhoneNumberComponent implements ProfileSetting {
   name: string = "Change phone number"
-  routerLink: string = "phone";
+  routerLink: string = "edit/phone";
 }

--- a/frontend/src/app/profile-dashboard/edit/edit.component.ts
+++ b/frontend/src/app/profile-dashboard/edit/edit.component.ts
@@ -11,7 +11,7 @@ import { ProfileSetting } from '../profile-dashboard.component';
 })
 export class EditComponent implements ProfileSetting {
   name: string = "Change personal details"
-  routerLink: string = "edit";
+  routerLink: string;
   elements?: ProfileSetting[] = [
     new EditPasswordComponent(),
     new EditEmailComponent(), 

--- a/frontend/src/app/profile-dashboard/fees/fees-accounted/fees-accounted.component.ts
+++ b/frontend/src/app/profile-dashboard/fees/fees-accounted/fees-accounted.component.ts
@@ -8,5 +8,5 @@ import { ProfileSetting } from '../../profile-dashboard.component';
 })
 export class FeesAccountedComponent implements ProfileSetting {
   name: string = "Accounted fees"
-  routerLink: string = "accounted";
+  routerLink: string = "fees/accounted";
 }

--- a/frontend/src/app/profile-dashboard/fees/fees-not-accounted/fees-not-accounted.component.ts
+++ b/frontend/src/app/profile-dashboard/fees/fees-not-accounted/fees-not-accounted.component.ts
@@ -8,5 +8,5 @@ import { ProfileSetting } from '../../profile-dashboard.component';
 })
 export class FeesNotAccountedComponent implements ProfileSetting {
   name: string = "Not accounted fees"
-  routerLink: string = "not-accounted";
+  routerLink: string = "fees/not-accounted";
 }

--- a/frontend/src/app/profile-dashboard/fees/fees.component.ts
+++ b/frontend/src/app/profile-dashboard/fees/fees.component.ts
@@ -10,7 +10,7 @@ import { ProfileSetting } from '../profile-dashboard.component';
 })
 export class FeesComponent implements ProfileSetting {
   name: string = "Fees";
-  routerLink: string = "fees";
+  routerLink: string;
   elements?: ProfileSetting[] = [
     new FeesNotAccountedComponent(),
     new FeesAccountedComponent()

--- a/frontend/src/app/profile-dashboard/profile-dashboard.component.html
+++ b/frontend/src/app/profile-dashboard/profile-dashboard.component.html
@@ -21,7 +21,7 @@
                             <ul>
                                 <li *ngFor="let el of option.elements" 
                                     [ngClass]="{'selected':  false}"
-                                    [routerLink]="option.routerLink + '/' + el.routerLink"
+                                    [routerLink]="el.routerLink"
                                     >
                                     {{el.name}}
                                 </li>

--- a/frontend/src/app/profile-dashboard/requested-items/requested-items-completed/requested-items-completed.component.ts
+++ b/frontend/src/app/profile-dashboard/requested-items/requested-items-completed/requested-items-completed.component.ts
@@ -12,7 +12,7 @@ import { ReservationService } from '../../../services/reservation.service';
 })
 export class RequestedItemsCompletedComponent implements ProfileSetting, OnInit {
   name: string = "Completed";
-  routerLink: string = "completed";
+  routerLink: string = "requested-items/completed";
   reservationService = inject(ReservationService);
   completedReservations: Array<Reservation>;
   authService = inject(AuthenticationService);

--- a/frontend/src/app/profile-dashboard/requested-items/requested-items-pending/requested-items-pending.component.ts
+++ b/frontend/src/app/profile-dashboard/requested-items/requested-items-pending/requested-items-pending.component.ts
@@ -12,7 +12,7 @@ import { PdfService } from '../../../services/pdf.service';
 })
 export class RequestedItemsPendingComponent implements ProfileSetting, OnInit {
   name: string = "Pending";
-  routerLink: string = "pending";
+  routerLink: string = "requested-items/pending";
   reservationService = inject(ReservationService);
   pendingReservations: Array<Reservation>;
   authService = inject(AuthenticationService);

--- a/frontend/src/app/profile-dashboard/requested-items/requested-items-unsent/requested-items-unsent.component.ts
+++ b/frontend/src/app/profile-dashboard/requested-items/requested-items-unsent/requested-items-unsent.component.ts
@@ -8,5 +8,5 @@ import { ProfileSetting } from '../../profile-dashboard.component';
 })
 export class RequestedItemsUnsentComponent implements ProfileSetting {
   name: string = "Unsent";
-  routerLink: string = "unsent";
+  routerLink: string = "requested-items/unsent";
 }

--- a/frontend/src/app/profile-dashboard/requested-items/requested-items.component.ts
+++ b/frontend/src/app/profile-dashboard/requested-items/requested-items.component.ts
@@ -11,7 +11,7 @@ import { RequestedItemsCompletedComponent } from './requested-items-completed/re
 })
 export class RequestedItemsComponent implements ProfileSetting {
   name: string = "Requested items";
-  routerLink: string = "requested-items";
+  routerLink: string;
   elements?: ProfileSetting[] = [
     new RequestedItemsUnsentComponent(),
     new RequestedItemsPendingComponent(),

--- a/frontend/src/bootstrap-fragments.css
+++ b/frontend/src/bootstrap-fragments.css
@@ -1,4 +1,3 @@
-FRAGMENT OF CODE FROM BOOTSTARP START
 :root {
     --bs-primary-bg-subtle: #cfe2ff;
     --bs-body-color: #212529;
@@ -97,21 +96,26 @@ FRAGMENT OF CODE FROM BOOTSTARP START
     z-index: 2;
 }
 .accordion-button:focus,
-.list-button:focus {
+.list-button:focus,
+.accordion-body li:focus {
     z-index: 3;
     outline: 0;
     box-shadow: var(--bs-accordion-btn-focus-box-shadow);
 }
 
-.accordion button:focus {
+.accordion button:focus,
+.accordion-body li:focus {
     background-color: var(--main-color);
     color: #fff;
 }
 
-.accordion-header {
+.accordion-header,
+.accordion-body li {
     margin-bottom: 0;
-    border: 1px solid;
+    border-bottom: 1px solid #D7D7D7;
+    border-right: 1px solid #D7D7D7;
 }
+
 .accordion-item {
     color: var(--bs-accordion-color);
     background-color: var(--bs-accordion-bg);
@@ -141,10 +145,18 @@ FRAGMENT OF CODE FROM BOOTSTARP START
     border-bottom-right-radius: var(--bs-accordion-border-radius);
     border-bottom-left-radius: var(--bs-accordion-border-radius);
 }
-.accordion-body {
-    padding: var(--bs-accordion-body-padding-y) var(--bs-accordion-body-padding-x);
-    border: 1px solid;
+
+.accordion-body li {
+    font-family: var(--font-family-1);
+    line-height: 1;
+    padding: var(--bs-accordion-btn-padding-y) var(--bs-accordion-btn-padding-x);
+    padding-left: calc(var(--bs-accordion-btn-padding-x) * 2);
 }
+
+.accordion-body li:hover {
+    color: #fff;
+}
+
 .accordion-flush > .accordion-item {
     border-right: 0;
     border-left: 0;


### PR DESCRIPTION
## 🚀 What?
This pull request addresses the following changes:

1. **Routing Structure and Accordion Behavior**:
   - Refactored the routing structure in `app-routing.module.ts`.
   - Improved the behavior of the accordion component.

2. **CSS Styling**:
   - Updated CSS for font management, borders, and accordion styling.

## 🎯 Why?
The changes were necessary to:
- Simplify and clean up the routing structure for better maintainability.
- Enhance user experience by improving the accordion's navigation and display.
- Ensure consistent and cohesive styling across the application, particularly in the accordion component and its sub-elements.

## 🔧 How?
1. **Routing Structure and Accordion Behavior**:
   - Removed nested child routes to create a more manageable structure.
   - Updated paths in individual components to match the new routing schema.
   - Modified the accordion list to handle navigation correctly.
   - Made the parent element toggle the visibility of its child elements instead of navigating away.
   - Ensured that clicking on an element with sub-elements expands to show the sub-elements without changing the route.

2. **CSS Styling**:
   - Moved font-family definitions to root variables for easier management and consistency.
   - Removed the left border from the `.content` class to create a cleaner look.
   - Updated borders within the accordion for a consistent design.
   - Ensured that accordion sub-elements have the same shape, hover effects, and font as their parent elements for a unified appearance.

## ✔️ Testing?

1. Log in using one of the test accounts, such as the admin account (username: `admin@example.com`, password: `adminpass`). Next, press the `Profile` button.
2. When you click on the expandable element in the accordion, it should expand and does not navigate to any page.

## 📸 Screenshots
- Accordion before:
![obraz](https://github.com/lukaszgardecki/library-app/assets/105553857/dc45360f-c394-44a5-864c-a487b22272c7)
- Accordion after:
![obraz](https://github.com/lukaszgardecki/library-app/assets/105553857/c65cb2b0-a654-43e6-94f9-4743d9849637)
