### PR TITLE
[FEATURE][F-59] Add back button to the book details page

### DIFF
--- a/frontend/src/app/user-page/book-details/book-details.component.html
+++ b/frontend/src/app/user-page/book-details/book-details.component.html
@@ -15,6 +15,12 @@
     <main class="hoc container clear">
 
         <div class="content">
+            <div class="btn-bar">
+                <button class="button btn-1" (click)="goBack()">Back</button>
+                <!-- <div class="right-side">
+                  <button class="button btn-2 btn-delete" >Delete</button>
+                </div> -->
+            </div>
 
             <h1 class="font-x2">{{book.title}}</h1>
             <div class="desc">

--- a/frontend/src/app/user-page/home-page/styles/layout.css
+++ b/frontend/src/app/user-page/home-page/styles/layout.css
@@ -154,7 +154,7 @@ File: Layout CSS
 #book-details .item-section-actions{ width: 25%; display: grid; grid-template-rows: repeat(4, 1fr);}
 #book-details .item-status {display: flex; border-bottom: 1px solid; align-items: center; justify-content: center;}
 #book-details .item-status span{margin-left: 10px;}
-#book-details button{width: 100%; height: 100%; border: none; cursor: pointer; transition: background-color 0.3s ease;}
+#book-details .item-section-actions button{width: 100%; height: 100%; border: none; cursor: pointer; transition: background-color 0.3s ease;}
 
 
 /* Sidebar */

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -5,6 +5,10 @@
     margin-bottom: 20px;
 }
 
+#book-details .btn-bar {
+    margin-bottom: 50px;
+}
+
 .right-side {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
## 🚀 What?

Added a `Back` button to the book details page.

## 🎯 Why?

The button allows returning to the previous location (book list or notification content if the previous location was the notification details page).

## 🛠️ How?

Updated book details component HTML template and added a few styles.

## ✅ Testing?

**Case 1:**
1. Go to `/books` (or click `Books` on the navigation bar) and select a book to display its details.
2. Press the `Back` button. You should be redirected to the previous page.

**Case 2:**
1. Log in using one of the test accounts, e.g., the admin account (username: `user@example.com`, password: `userpass`), press the `Profile` button and then click `Notifications`.
2. Press `Profile` -> `Notifications` -> Click any element on the list -> Click the document title (link). The book details page should be displayed.
3. Press the `Back` button. You should be redirected to the previous page.

## 📸 Screenshots
![obraz](https://github.com/lukaszgardecki/library-app/assets/105553857/e2662b20-9a8e-4127-8c55-ba73548891c3)
![obraz](https://github.com/lukaszgardecki/library-app/assets/105553857/9b7c4000-47e9-4a27-bd47-def3d3cf330b)
