### PR TITLE
[FEATURE][F-66] Dashboard

### DIFF
--- a/frontend/src/app/modules/catalog/pages/dashboard/dashboard.component.css
+++ b/frontend/src/app/modules/catalog/pages/dashboard/dashboard.component.css
@@ -1,0 +1,85 @@
+/* COLOR TILES */
+.small-box {
+    border-radius: 0.375rem;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    position: relative;
+    display: block;
+    margin-bottom: 1.25rem;
+    height: 100%;
+    --bs-link-color-rgb: none;
+    --bs-link-hover-color-rgb: none;
+    --bs-heading-color: none;
+  }
+  
+  .small-box.add-user-btn {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+    background-color: rgba(255, 193, 7, 0.2);
+    text-transform: uppercase;
+    font-weight: bold;
+    border: 3px dashed #ffc107;
+    user-select: none;
+    text-size-adjust: 100%;
+  }
+  
+  .small-box.add-user-btn:hover {
+    cursor: pointer;
+    transform: scale(1.03);
+    box-shadow: 0 10px 10px rgba(0, 0, 0, 0.2);
+  }
+  
+  .small-box.add-user-btn .small-box-icon::before {
+    position: relative;
+    color: #ffc107;
+    right:auto;
+    top: auto;
+  }
+  
+  .small-box > .inner {
+    padding: 10px;
+    height: 100%;
+  }
+  
+  .small-box .inner {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+    padding: 10px;
+  }
+  
+  .small-box .inner h3 {
+    margin: 0;
+    align-self: flex-start;
+  }
+  
+  .small-box .inner p {
+    font-size: 1rem;
+    margin: 0;
+    flex-grow: 1;
+    display: flex;
+    align-items: center;
+  }
+  
+  .small-box .small-box-icon::before {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    z-index: 0;
+    font-size: 3rem;
+    color: rgba(0, 0, 0, 0.15);
+    transition: transform 0.3s linear;
+  }
+  
+  .small-box:hover .small-box-icon::before {
+    transform: scale(1.1);
+  }
+  
+  .form-select:focus,
+  .form-control:focus {
+    border-color: var(--bs-dark-border-subtle);
+    box-shadow: 0 0 0 0.2rem var(--bs-dark-border-subtle);
+  }

--- a/frontend/src/app/modules/catalog/pages/dashboard/dashboard.component.html
+++ b/frontend/src/app/modules/catalog/pages/dashboard/dashboard.component.html
@@ -1,1 +1,107 @@
-<p>dashboard works</p>
+<div class="container-fluid">
+
+    <h1 class="h2">{{ 'CAT.SIDEBAR.DASHBOARD' | translate }}</h1>
+  
+    <div class="row">
+      <div class="col-lg-3 col-md-6 col-sm-6 col-12 p-2">
+          <div class="small-box text-bg-primary">
+              <div class="inner">
+                  <h3 *ngIf="usersStats$ | async as stats">{{ stats.todayLoans }}</h3>
+                  <p>{{ 'CAT.STATS.LENDINGS_COUNT_TODAY' | translate }}</p>
+              </div>
+              <i class="bi bi-bookmark-check small-box-icon"></i>
+          </div>
+      </div>
+      <div class="col-lg-3 col-md-6 col-sm-6 col-12 p-2">
+          <div class="small-box text-bg-success">
+              <div class="inner">
+                  <h3 *ngIf="usersStats$ | async as stats">{{ stats.activeUsersThisMonth }}</h3>
+                  <p>{{ 'CAT.STATS.USERS_ACTIVE_THIS_MONTH' | translate }}</p>
+              </div>
+              <i class="bi bi-activity small-box-icon"></i>
+          </div>
+      </div>
+      <div class="col-lg-3 col-md-6 col-sm-6 col-12 p-2">
+          <div class="small-box text-bg-warning">
+              <div class="inner">
+                  <h3 *ngIf="usersStats$ | async as stats">{{ stats.newUsersThisMonth }}</h3>
+                  <p>{{ 'CAT.STATS.USERS_NEW_THIS_MONTH' | translate }}</p>
+              </div>
+              <i class="bi bi-person-plus-fill small-box-icon"></i>
+          </div>
+      </div>
+      <div class="col-lg-3 col-md-6 col-sm-6 col-12 p-2">
+          <div class="small-box text-bg-danger">
+              <div class="inner">
+                  <h3 *ngIf="usersStats$ | async as stats">{{ stats.usersCount }}</h3>
+                  <p>{{ 'CAT.STATS.USERS_TOTAL' | translate }}</p>
+              </div>
+              <i class="bi bi-people-fill small-box-icon"></i>
+          </div>
+      </div>
+    </div>
+    
+    <div class="row">
+      <app-basic-section class="col-12 col-md-6 col-xxl-3 p-2" [name]="'CAT.USER.ACCOUNT.LENDINGS_WEEKLY' | translate">
+        <app-weekly-activity-chart
+          *ngIf="usersStats$ | async as stats; else lack"
+          [data1]="stats.newLoansLastWeekByDay"
+          [data2]="stats.returnedLoansLastWeekByDay"
+        ></app-weekly-activity-chart>
+      </app-basic-section>
+  
+      <app-basic-section class="col-12 col-md-6 col-xxl-3 p-2" [name]="'CAT.USER.ACCOUNT.LENDINGS_ANNUAL' | translate">
+        <app-annual-activity-chart
+          *ngIf="usersStats$ | async as stats; else lack"
+          [data]="stats.loansLastYearByMonth"
+        ></app-annual-activity-chart>
+      </app-basic-section>
+  
+      <app-basic-section class="col-12 col-md-6 col-xxl-3 p-2" [name]="'CAT.USER.ACCOUNT.FAV_GENRES' | translate">
+        <app-fav-genre-chart
+          *ngIf="usersStats$ | async as stats; else lack"
+          [data]="stats.favGenres"
+        ></app-fav-genre-chart>
+      </app-basic-section>
+  
+      <app-basic-section class="col-md-6 col-sm-12 col-12 col-xxl-3 p-2" [name]="'CAT.STATS.USERS_AGE_GROUPS.HEADER' | translate">
+        <app-users-age-groups-chart
+          *ngIf="usersStats$ | async as stats; else lack"
+          [data]="stats.ageGroups"
+        ></app-users-age-groups-chart>
+      </app-basic-section>
+  
+      <app-basic-section class="col-md-6 col-sm-12 col-12 col-xxl-3 p-2" [name]="'CAT.STATS.USERS_TOP_CITIES' | translate">
+        <app-top-cities
+          *ngIf="usersStats$ | async as stats; else lack"
+          [columns]="[
+              'CAT.USER.DETAILS.CITY' ,
+              'CAT.STATS.AMOUNT' ,
+          ]"
+          [data]="stats.topCities"
+        ></app-top-cities>
+      </app-basic-section>
+
+      <app-basic-section class="col-12 col-md-6 col-xxl-3 p-2" [name]="'CAT.STATS.USERS_TOP_BORROWERS' | translate">
+        <app-table
+          *ngIf="usersStats$ | async as stats; else lack"
+          [tableName]="'top-users-list'"
+          [columns]="[
+              { key: 'rank', label: 'CAT.STATS.RANK' },
+              { key: 'fullName', label: 'CAT.USER.BORROWER' },
+              { key: 'totalBooksBorrowed', label: 'CAT.USER.ACCOUNT.LENDINGS' },
+          ]"
+          [data]="stats.topBorrowers || []"
+          (onRowClick)="showDetails($event)"
+          [options]="{
+            pagination: false,
+            searchField: false,
+            pageSize: false,
+            shareExportBtns: false
+          }"
+        ></app-table>
+      </app-basic-section>
+  </div>
+  
+  
+  <ng-template #lack>{{ 'DATA.LACK' | translate }}</ng-template>

--- a/frontend/src/app/modules/catalog/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/modules/catalog/pages/dashboard/dashboard.component.ts
@@ -1,12 +1,48 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { AnnualActivityChartComponent } from '../../components/charts/annual-activity-chart/annual-activity-chart.component';
+import { FavGenreChartComponent } from '../../components/charts/fav-genre-chart/fav-genre-chart.component';
+import { UsersAgeGroupsChartComponent } from '../../components/charts/users-age-groups-chart/users-age-groups-chart.component';
+import { WeeklyActivityChartComponent } from '../../components/charts/weekly-activity-chart/weekly-activity-chart.component';
+import { BasicSectionComponent } from '../../components/sections/basic-section/basic-section.component';
+import { TableComponent } from '../../components/tables/table/table.component';
+import { TopCitiesComponent } from '../../components/tables/top-cities/top-cities.component';
+import { Observable } from 'rxjs';
+import { Statistics } from '../../shared/models/users-stats-admin';
+import { UserListPreviewAdmin, UserTopBorrowersAdmin } from '../../shared/models/user-details';
+import { UserService } from '../../core/services/user.service';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [],
+  imports: [
+    CommonModule, TranslateModule, RouterModule,
+    TableComponent, FavGenreChartComponent, AnnualActivityChartComponent,
+    WeeklyActivityChartComponent,
+    UsersAgeGroupsChartComponent,
+    TopCitiesComponent,
+    BasicSectionComponent
+  ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.css'
 })
-export class DashboardComponent {
-  
+export class DashboardComponent implements OnInit {
+  usersStats$: Observable<Statistics>;
+
+  constructor(
+    private userService: UserService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) { }
+
+  ngOnInit(): void {
+    this.usersStats$ = this.userService.getUsersStatsAdmin();
+  }
+
+  showDetails(userPreview: UserListPreviewAdmin | UserTopBorrowersAdmin) {
+      const userId = userPreview.id;
+      this.router.navigate([userId], { relativeTo: this.route });
+    }
 }


### PR DESCRIPTION
## 🚀 What?

Introduced a dedicated **Admin Dashboard** panel.

## 🎯 Why?

Previously, the admin dashboard (statistical data and insights) was located under the **"Users"** tab, mixed with the user management table.  
To improve clarity, usability, and separation of concerns, the dashboard has now been extracted into its own standalone section: **"Dashboard"**.  
The **"Users"** tab now only displays the user table and related management actions.

## 🛠️ How?

The new **Dashboard** was created by extracting existing statistical information from the **Users** page and moving it into a separate component/view.

## ✅ Testing?
1. Log in using one of the test accounts, such as the admin account (username: admin@example.com, password: `adminpass`).
2. The dashboard will be the first page you see after logging in.

## 📸 Screenshots
![obraz](https://github.com/user-attachments/assets/0d831e91-961b-4ddf-abe4-aa3bb7a10c21)
